### PR TITLE
Allow using simplified import statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ Let's look at `gameStateBar.jsx` as an example.
 
 Step one is to rename `gameStateBar.jsx` to `gameStateBar.tsx`. If you are using any editor with TypeScript support such as [Visual Studio Code](https://code.visualstudio.com/), you should be able to see a few complaints from your editor.
 
-On line 1 `import React from "react";`, change the import statement to `import * as React from "react"`. This is because while importing a CommonJS module, Babel assumes `modules.export` as default export, while TypeScript does not.
+Add option `"allowSyntheticDefaultImports": true` in your `tsconfig.json` file to allow TypeScript compiler use default imports from modules with no default export. In TypeScript version 2.7.0 or newer you can use `"esModuleInterop": true` option to achieve the same results: [TypeScript 2.7
+Release Notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html) for more on this feature.
 
 On line 3 `export class GameStateBar extends React.Component {`, change the class declaration to `export class GameStateBar extends React.Component<any, any> {`. The type declaration of `React.Component` uses [generic types](https://www.typescriptlang.org/docs/handbook/generics.html) and requires providing the types for the property and state object for the component. The use of `any` allows us to pass in any value as the property or state object, which is not useful in terms of type checking but suffices as minimum effort to appease the compiler.
 

--- a/TicTacToe_TS/src/app.tsx
+++ b/TicTacToe_TS/src/app.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { render } from "react-dom";
 import { Board } from "./Board";
 import { RestartBtn } from "./RestartBtn";

--- a/TicTacToe_TS/src/board.tsx
+++ b/TicTacToe_TS/src/board.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { CellValue, GameState, playerCell, aiCell } from "./constants"; 
 
 interface BoardState {

--- a/TicTacToe_TS/src/gameStateBar.tsx
+++ b/TicTacToe_TS/src/gameStateBar.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { GameState } from "./constants";
 
 interface GameStateBarState {

--- a/TicTacToe_TS/src/restartBtn.tsx
+++ b/TicTacToe_TS/src/restartBtn.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 export class RestartBtn extends React.Component<{}, {}> {
 

--- a/TicTacToe_TS/tsconfig.json
+++ b/TicTacToe_TS/tsconfig.json
@@ -7,7 +7,8 @@
         "jsx": "react",             // use typescript to transpile jsx to js
         "target": "es5",            // specify ECMAScript target version
         "allowJs": true,            // allow a partial TypeScript and JavaScript codebase  
-        "noImplicitAny": true       // disallow implicit any type
+        "noImplicitAny": true,       // disallow implicit any type
+        "allowSyntheticDefaultImports": true, // Allow default imports from modules with no default export
     },
     "include": [
         "./src/"


### PR DESCRIPTION
Adding --allowSyntheticDefaultImports option let people use the same imports
as in the code under migration

In TS 2.7 there is --esModuleInterop option introduced exactly for the same reason

Thanks!