### PR TITLE
Exclude node_modules in Webpack rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ module.exports = {
   },
   module: {
     rules: [
-      // changed from { test: /\.jsx?$/, use: { loader: 'babel-loader' } },
-      { test: /\.(t|j)sx?$/, use: { loader: 'awesome-typescript-loader' } },
+      // changed from { test: /\.jsx?$/, exclude: /node_modules/, use: { loader: 'babel-loader' } },
+      { test: /\.(t|j)sx?$/, exclude: /node_modules/, use: { loader: 'awesome-typescript-loader' } },
       // addition - add source-map support
-      { enforce: "pre", test: /\.js$/, loader: "source-map-loader" }
+      { enforce: "pre", test: /\.js$/, exclude: /node_modules/, loader: "source-map-loader" }
     ]
   },
   externals: {

--- a/TicTacToe_JS/webpack.config.js
+++ b/TicTacToe_JS/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
   },
   module: {
     rules: [
-      { test: /\.jsx?$/, use: { loader: 'babel-loader' } }
+      { test: /\.jsx?$/, exclude: /node_modules/, use: { loader: 'babel-loader' } }
     ]
   },
   externals: {

--- a/TicTacToe_TS/webpack.config.js
+++ b/TicTacToe_TS/webpack.config.js
@@ -10,10 +10,10 @@ module.exports = {
   },
   module: {
     rules: [
-      // changed from { test: /\.jsx?$/, use: { loader: 'babel-loader' } },
-      { test: /\.(t|j)sx?$/, use: { loader: 'awesome-typescript-loader' } },
+      // changed from { test: /\.jsx?$/, exclude: /node_modules/, use: { loader: 'babel-loader' } },
+      { test: /\.(t|j)sx?$/, exclude: /node_modules/, use: { loader: 'awesome-typescript-loader' } },
       // newline - add source-map support 
-      { enforce: "pre", test: /\.js$/, loader: "source-map-loader" }
+      { enforce: "pre", test: /\.js$/, exclude: /node_modules/, loader: "source-map-loader" }
     ]
   },
   externals: {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/TypeScript-React-Conversion-Guide/issues/7

Improves build times by excluding the node_modules directory. 

Those lines are getting a little long making it harder to read. Let me know if they should be split onto multiple lines. 

Thanks!