### PR TITLE
[#17] Fix version issue with awesome-typescript-loader.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm install
 Additionally, install TypeScript (2.3 or higher), [awesome-typescript-loader](https://www.npmjs.com/package/awesome-typescript-loader) and [source-map-loader](https://www.npmjs.com/package/source-map-loader) as dev dependencies if you haven't. awesome-typescript-loader is a Webpack plugin that helps you compile TypeScript code to JavaScript, much like babel-loader for Babel. There are also other alternative loaders for TypeScript, such as [ts-loader](https://github.com/TypeStrong/ts-loader). source-map-loader adds source map support for debugging.
 
 ```sh
-npm install --save-dev typescript awesome-typescript-loader source-map-loader
+npm install --save-dev typescript awesome-typescript-loader@4 source-map-loader
 ```
 
 Get the type declaration files (.d.ts files) from [@types](https://blogs.msdn.microsoft.com/typescript/2016/06/15/the-future-of-declaration-files/) for any library in use. For this project, we have React and ReactDOM.
@@ -72,7 +72,8 @@ Next, configure TypeScript by creating a `tsconfig.json` file in the `TicTacToe_
         "module": "es6",            // specify module code generation
         "jsx": "react",             // use typescript to transpile jsx to js
         "target": "es5",            // specify ECMAScript target version
-        "allowJs": true             // allow a partial TypeScript and JavaScript codebase
+        "allowJs": true,            // allow a partial TypeScript and JavaScript codebase
+        "moduleResolution": "node"  // for knowledge of node_module directory
 
     },
     "include": [

--- a/TicTacToe_TS/package.json
+++ b/TicTacToe_TS/package.json
@@ -9,9 +9,9 @@
     "react-dom": "^15.4.2"
   },
   "devDependencies": {
-    "webpack": "^2.3.3",
-    "typescript": "^2.3.2",
-    "awesome-typescript-loader": "^3.1.2",
-    "source-map-loader": "^0.2.1"
+    "awesome-typescript-loader": "^4.0.1",
+    "source-map-loader": "^0.2.4",
+    "typescript": "^3.2.2",
+    "webpack": "^2.3.3"
   }
 }

--- a/TicTacToe_TS/tsconfig.json
+++ b/TicTacToe_TS/tsconfig.json
@@ -7,7 +7,8 @@
         "jsx": "react",             // use typescript to transpile jsx to js
         "target": "es5",            // specify ECMAScript target version
         "allowJs": true,            // allow a partial TypeScript and JavaScript codebase  
-        "noImplicitAny": true       // disallow implicit any type
+        "noImplicitAny": true,       // disallow implicit any type
+        "moduleResolution": "node"  // for knowledge of node_module directory
     },
     "include": [
         "./src/"


### PR DESCRIPTION
- Version 5 of awesome-ts-loader doesnt work with the webpack version installed. Capped at version 4.
- Added moduleResolution: "node" to tsconfig as seemed necessary for the current version of these modules now.
- Update readme to reflect this.

Fixes issue the person in #17 was experiencing which I also ran into.

A more complete fix would be updating webpack, but... 😅